### PR TITLE
POD: improve indent of the ternary <?:> example

### DIFF
--- a/lib/Cond/Expr.pm
+++ b/lib/Cond/Expr.pm
@@ -58,11 +58,11 @@ Using nested ternary C<?:> expressions, such as in
 
   my %args = (
       foo => 'bar',
-      (($answer == 42)
-          ? (answer => $answer)
-              : ($answer)
-                  ? (wrong_answer => 1)
-                      : (no_answer => 1)),
+      (
+            ($answer == 42) ? (answer => $answer)
+          : ($answer)       ? (wrong_answer => 1)
+          :                   (no_answer => 1)
+      ),
   );
 
 can be used to achieve functionality similar to what this module provides. In


### PR DESCRIPTION
Improve the indent of the ternary <?:> example to be quite similar to the SYNOPSIS.

_Note: I'm not convinced by the argument that Cond::Expr is easier to the eye._
